### PR TITLE
Apply any/local-revert-bz13979.diff

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+glibc (2.35-deepin1) unstable; urgency=medium
+
+  * Apply any/local-revert-bz13979.diff.
+
+ -- Tianyu Chen <chentianyu1@uniontech.com>  Tue, 25 Apr 2023 15:28:50 +0800
+
 glibc (2.35-deepin) stable; urgency=medium
 
   * ['Rebuild  against by  current gcc 11.2']

--- a/debian/patches/any/local-revert-bz13979.diff
+++ b/debian/patches/any/local-revert-bz13979.diff
@@ -14,7 +14,7 @@ Warn if user requests __FORTIFY_SOURCE but it is disabled
 
 --- a/include/features.h
 +++ b/include/features.h
-@@ -392,10 +392,9 @@
+@@ -407,10 +407,9 @@
  # define __USE_GNU	1
  #endif
  
@@ -26,5 +26,5 @@ Warn if user requests __FORTIFY_SOURCE but it is disabled
 +    && defined __OPTIMIZE__ && __OPTIMIZE__ > 0
 +# if !__GNUC_PREREQ (4, 1)
  #  warning _FORTIFY_SOURCE requires GCC 4.1 or later
- # elif _FORTIFY_SOURCE > 2 && __glibc_clang_prereq (9, 0)
- #  if _FORTIFY_SOURCE > 3
+ # elif _FORTIFY_SOURCE > 2 && (__glibc_clang_prereq (9, 0)		      \
+ 			       || __GNUC_PREREQ (12, 0))

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+any/local-revert-bz13979.diff


### PR DESCRIPTION
Apply any/local-revert-bz13979.diff so `_FORTIFY_SOURCE` with `-O0` won't show warning.