### PR TITLE
feat: compatible mode

### DIFF
--- a/debian/patches/any/compat_mode.patch
+++ b/debian/patches/any/compat_mode.patch
@@ -1,0 +1,320 @@
+Index: ldrd/elf/dl-load.c
+===================================================================
+--- ldrd.orig/elf/dl-load.c
++++ ldrd/elf/dl-load.c
+@@ -101,6 +101,10 @@ int __stack_prot attribute_hidden attrib
+ 
+ /* This is the decomposed LD_LIBRARY_PATH search path.  */
+ struct r_search_path_struct __rtld_env_path_list attribute_relro;
++#ifdef COMPAT_MODE
++struct r_search_path_struct __rtld_subsys_path_list attribute_relro; //子系统
++int __run_path_mode attribute_relro; //子系统
++#endif
+ 
+ /* List of the hardware capabilities we might end up using.  */
+ #ifdef SHARED
+@@ -698,6 +702,54 @@ cache_rpath (struct link_map *l,
+ 			  l, what);
+ }
+ 
++#ifdef COMPAT_MODE
++void _init_subsystem_path(const char *llp, const char *source)
++{
++
++  const char *errstring = NULL;
++  struct link_map __attribute__ ((unused)) *l = NULL;
++
++  l = GL(dl_ns)[LM_ID_BASE]._ns_loaded;
++#ifdef SHARED
++  if (l == NULL)
++    l = &GL (dl_rtld_map);
++#endif
++  assert (l->l_type != lt_loaded);
++
++  if (llp != NULL && *llp != '\0')
++    {
++      char *llp_tmp = strdupa (llp);
++
++      /* Decompose the LD_SYSTERM_PATH contents.  First determine how many
++	 elements it has.  */
++      size_t nllp = 1;
++      for (const char *cp = llp_tmp; *cp != '\0'; ++cp)
++	if (*cp == ':' || *cp == ';')
++	  ++nllp;
++
++      __rtld_subsys_path_list.dirs = (struct r_search_path_elem **)
++	malloc ((nllp + 1) * sizeof (struct r_search_path_elem *));//初始化LD_SYSTEM_PATH
++      if (__rtld_subsys_path_list.dirs == NULL)
++	{
++	  errstring = N_("cannot create cache for subsys search path");
++	  _dl_signal_error (ENOMEM, NULL, NULL, errstring);
++	}
++
++      (void) fillin_rpath (llp_tmp, __rtld_subsys_path_list.dirs, ":;", //初始化环境变量字符串到subsys_path
++			   source, NULL, l);
++
++      if (__rtld_subsys_path_list.dirs[0] == NULL)
++	{
++	  free (__rtld_subsys_path_list.dirs);
++	  __rtld_subsys_path_list.dirs = (void *) -1;
++	}
++
++      __rtld_subsys_path_list.malloced = 0;
++    }
++  else
++    __rtld_subsys_path_list.dirs = (void *) -1;	
++}
++#endif
+ 
+ void
+ _dl_init_paths (const char *llp, const char *source,
+@@ -1968,6 +2020,8 @@ _dl_map_object (struct link_map *loader,
+   char *name_copy;
+   struct link_map *l;
+   struct filebuf fb;
++  struct r_search_path_struct l_rpath_dirs;
++  l_rpath_dirs.dirs = NULL;
+ 
+   assert (nsid >= 0);
+   assert (nsid < GL(dl_nns));
+@@ -2082,10 +2136,11 @@ _dl_map_object (struct link_map *loader,
+ 	      && fd == -1 && !did_main_map
+ 	      && main_map != NULL && main_map->l_type != lt_loaded)
+ 	    {
+-	      struct r_search_path_struct l_rpath_dirs;
+-	      l_rpath_dirs.dirs = NULL;
+ 	      if (cache_rpath (main_map, &l_rpath_dirs,
+ 			       DT_RUNPATH, "RUNPATH"))
++#ifdef COMPAT_MODE
++      		if (__run_path_mode == 2) //2=normal;1=lazy;0=sikp
++#endif
+ 		fd = open_path (name, namelen, mode, &l_rpath_dirs,
+ 				&realname, &fb, loader ?: main_map,
+ 				LA_SER_RUNPATH, &found_other_class);
+@@ -2093,6 +2148,9 @@ _dl_map_object (struct link_map *loader,
+ 	}
+ 
+       /* Try the LD_LIBRARY_PATH environment variable.  */
++#ifdef COMPAT_MODE
++      if (__rtld_env_path_list.mode == 0)
++#endif
+       if (fd == -1 && __rtld_env_path_list.dirs != (void *) -1)
+ 	fd = open_path (name, namelen, mode, &__rtld_env_path_list,
+ 			&realname, &fb,
+@@ -2122,6 +2180,9 @@ _dl_map_object (struct link_map *loader,
+         }
+ 
+ #ifdef USE_LDCONFIG
++#ifdef COMPAT_MODE
++      if (__rtld_search_dirs.mode != 0)
++#endif
+       if (fd == -1
+ 	  && (__glibc_likely ((mode & __RTLD_SECURE) == 0)
+ 	      || ! __libc_enable_secure)
+@@ -2180,12 +2241,37 @@ _dl_map_object (struct link_map *loader,
+ #endif
+ 
+       /* Finally, try the default path.  */
++#ifdef COMPAT_MODE
++      if (__rtld_search_dirs.mode != 0)
++#endif
+       if (fd == -1
+ 	  && ((l = loader ?: GL(dl_ns)[nsid]._ns_loaded) == NULL
+ 	      || __glibc_likely (!(l->l_flags_1 & DF_1_NODEFLIB)))
+ 	  && __rtld_search_dirs.dirs != (void *) -1)
+ 	fd = open_path (name, namelen, mode, &__rtld_search_dirs,
+ 			&realname, &fb, l, LA_SER_DEFAULT, &found_other_class);
++#ifdef COMPAT_MODE
++      /*  LD_LIBRARY_PATH lazy load .  */
++      if ( __rtld_env_path_list.mode == 1 && fd == -1 && __rtld_env_path_list.dirs != (void *) -1)
++	fd = open_path (name, namelen, mode, &__rtld_env_path_list,
++			&realname, &fb,
++			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
++			LA_SER_LIBPATH, &found_other_class);//LD_LIBRARY_PATH延迟加载
++
++      /*  RUN_PATH lazy load .  */
++      if ( fd == -1 && __rtld_search_dirs.dirs !=NULL  && __run_path_mode == 1)
++	fd = open_path (name, namelen, mode, &l_rpath_dirs,
++				&realname, &fb,
++			        loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
++				LA_SER_RUNPATH, &found_other_class);
++      
++      /* search LD_SYSTEM_PATH */
++      if (fd == -1 && __rtld_subsys_path_list.dirs != (void *) -1)
++	fd = open_path (name, namelen, mode, &__rtld_subsys_path_list,
++			&realname, &fb,
++			loader ?: GL(dl_ns)[LM_ID_BASE]._ns_loaded,
++			LA_SER_LIBPATH, &found_other_class);//LD_SYSTEM_PATH
++#endif
+ 
+       /* Add another newline when we are tracing the library loading.  */
+       if (__glibc_unlikely (GLRO(dl_debug_mask) & DL_DEBUG_LIBS))
+Index: ldrd/elf/dl-main.h
+===================================================================
+--- ldrd.orig/elf/dl-main.h
++++ ldrd/elf/dl-main.h
+@@ -77,6 +77,18 @@ struct dl_main_state
+ 
+   /* Where library_path comes from.  LD_LIBRARY_PATH or --library-path.  */
+   const char *library_path_source;
++#ifdef COMPAT_MODE 
++  /* Control the library_path work stage, enable lazy mode.  */
++  const char *library_path_mode;
++  const char *run_path_mode;
++  const char *sys_path_mode;
++
++  /* The subsystem search path.  */
++  const char *subsystem_path;
++
++  /* Where library_path comes from.  LD_SYSTEM_PATH .  */
++  const char *subsystem_path_source;
++#endif
+ 
+   /* The list preloaded objects from LD_PRELOAD.  */
+   const char *preloadlist;
+@@ -104,6 +116,35 @@ struct dl_main_state
+   bool version_info;
+ };
+ 
++#ifdef COMPAT_MODE 
++//通过state获取环境变量来设置__rtld_env_path_list.mode
++static void _enable_lazy_library (const struct dl_main_state* state)
++{
++   __rtld_env_path_list.mode = 0;
++   __rtld_search_dirs.mode = 1;
++   __run_path_mode = 2;
++
++   if(state->library_path_mode)
++   {
++      __rtld_env_path_list.mode = 1;//启用lazy
++   }
++
++   if(state->run_path_mode !=NULL && memcmp(state->run_path_mode,"LAZY",4) == 0)
++   {
++      __run_path_mode = 1;
++   }
++   if(state->run_path_mode !=NULL && memcmp(state->run_path_mode,"IGNORE",6) == 0)
++   {
++      __run_path_mode = 0;
++   }
++
++   if(state->sys_path_mode !=NULL &&  memcmp(state->sys_path_mode,"IGNORE",6) == 0)
++   {
++      __rtld_search_dirs.mode = 0;//disable v25 default  sys path
++   }
++}
++#endif
++
+ /* Helper function to invoke _dl_init_paths with the right arguments
+    from *STATE.  */
+ static inline void
+@@ -111,6 +152,10 @@ call_init_paths (const struct dl_main_st
+ {
+   _dl_init_paths (state->library_path, state->library_path_source,
+                   state->glibc_hwcaps_prepend, state->glibc_hwcaps_mask);
++#ifdef COMPAT_MODE 
++  _init_subsystem_path (state->subsystem_path, state->subsystem_path_source);//初始化系统变量
++  _enable_lazy_library (state);
++#endif	     
+ }
+ 
+ /* Print ld.so usage information and exit.  */
+Index: ldrd/elf/rtld.c
+===================================================================
+--- ldrd.orig/elf/rtld.c
++++ ldrd/elf/rtld.c
+@@ -295,6 +295,13 @@ dl_main_state_init (struct dl_main_state
+   audit_list_init (&state->audit_list);
+   state->library_path = NULL;
+   state->library_path_source = NULL;
++#ifdef COMPAT_MODE
++  state->library_path_mode = NULL;
++  state->run_path_mode = NULL;
++  state->sys_path_mode = NULL;
++  state->subsystem_path = NULL;
++  state->subsystem_path_source = NULL;  
++#endif  
+   state->preloadlist = NULL;
+   state->preloadarg = NULL;
+   state->glibc_hwcaps_prepend = NULL;
+@@ -2617,6 +2624,15 @@ process_envvars (struct dl_main_state *s
+ 
+ 	case 11:
+ 	  /* Path where the binary is found.  */
++#ifdef COMPAT_MODE
++	  if (!__libc_enable_secure
++	      && memcmp (envline, "SYSTEM_PATH", 11) == 0)
++	    {
++	      state->subsystem_path = &envline[12];
++	      state->subsystem_path_source = "LD_SYSTEM_PATH";
++	      break;
++	    }
++#endif
+ 	  if (!__libc_enable_secure
+ 	      && memcmp (envline, "ORIGIN_PATH", 11) == 0)
+ 	    GLRO(dl_origin_path) = &envline[12];
+@@ -2631,7 +2647,26 @@ process_envvars (struct dl_main_state *s
+ 	      state->library_path_source = "LD_LIBRARY_PATH";
+ 	      break;
+ 	    }
+-
++#ifdef COMPAT_MODE
++	  if (!__libc_enable_secure
++	      && memcmp (envline, "LIBRARY_MODE", 12) == 0)
++	    {
++	      state->library_path_mode = &envline[13];
++	      break;
++	    }
++	  if (!__libc_enable_secure
++	      && memcmp (envline, "RUNPATH_MODE", 12) == 0)
++	    {
++	      state->run_path_mode = &envline[13];
++	      break;
++	    }
++	  if (!__libc_enable_secure
++	      && memcmp (envline, "SYSPATH_MODE", 12) == 0)
++	    {
++	      state->sys_path_mode = &envline[13];
++	      break;
++	    }
++#endif
+ 	  /* Where to place the profiling data file.  */
+ 	  if (memcmp (envline, "DEBUG_OUTPUT", 12) == 0)
+ 	    {
+Index: ldrd/include/link.h
+===================================================================
+--- ldrd.orig/include/link.h
++++ ldrd/include/link.h
+@@ -77,11 +77,17 @@ struct r_search_path_struct
+   {
+     struct r_search_path_elem **dirs;
+     int malloced;
++#ifdef COMPAT_MODE
++    int mode;
++#endif
+   };
+ 
+ /* Search path information computed by _dl_init_paths.  */
+ extern struct r_search_path_struct __rtld_search_dirs attribute_hidden;
+ extern struct r_search_path_struct __rtld_env_path_list attribute_hidden;
++#ifdef COMPAT_MODE
++extern int __run_path_mode attribute_hidden;
++#endif
+ 
+ /* Structure describing a loaded shared object.  The `l_next' and `l_prev'
+    members form a chain of all the shared objects loaded at startup.
+Index: ldrd/sysdeps/generic/ldsodefs.h
+===================================================================
+--- ldrd.orig/sysdeps/generic/ldsodefs.h
++++ ldrd/sysdeps/generic/ldsodefs.h
+@@ -1078,7 +1078,9 @@ extern void _dl_init_paths (const char *
+ 			    const char *glibc_hwcaps_prepend,
+ 			    const char *glibc_hwcaps_mask)
+   attribute_hidden;
+-
++#ifdef COMPAT_MODE
++extern void _init_subsystem_path (const char *system_path, const char *source)  attribute_hidden;
++#endif
+ /* Gather the information needed to install the profiling tables and start
+    the timers.  */
+ extern void _dl_start_profile (void) attribute_hidden;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -132,3 +132,4 @@ loong64/0021-LoongArch-Replace-deprecated-v0-with-a0-to-eliminate.patch
 loong64/0022-LoongArch-Add-ifunc-support-for-strcpy-stpcpy-aligne.patch
 loong64/0023-LoongArch-Add-ifunc-support-for-strrchr-aligned-lsx-.patch
 loong64/0024-LoongArch-Change-to-put-magic-number-to-.rodata-sect.patch
+any/compat_mode.patch

--- a/debian/rules
+++ b/debian/rules
@@ -110,7 +110,7 @@ BUILD_CC = $(DEB_BUILD_GNU_TYPE)-$(BASE_CC)
 BUILD_CXX = $(DEB_BUILD_GNU_TYPE)-$(BASE_CXX)
 
 BUILD_CFLAGS = -O2 -g -fdebug-prefix-map=$(CURDIR)=.
-HOST_CFLAGS = -pipe -O2 -g -fdebug-prefix-map=$(CURDIR)=. $(call xx,extra_cflags)
+HOST_CFLAGS = -DCOMPAT_MODE -pipe -O2 -g -fdebug-prefix-map=$(CURDIR)=. $(call xx,extra_cflags)
 
 # 32-bit MIPS builders have a 2GB memory space. This is not enough to
 # build test-tgmath3.o with GCC, unless tweaking the garbage collector.


### PR DESCRIPTION
Description: search lib from subsystem ,and inhibit RUNPATH and LIBRARY, make sure library load order: host > subsystem > elf  specified spdir。
	ROOTFS=/lib/var/rootfs/debian10
	export LD_SYSTEM_PATH="$ROOTFS/lib:$ROOTFS/lib/x86_64-linux-gnu"
extra control env：
	LD_LIBRARY_MODE=LAZY
	LD_RUNPATH_MODE=LAZY/IGNORE
	LD_SYSPATH_MODE=IGNORE