### PR TITLE
fix: sw64 getpriority wrong

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+glibc (2.38-6deepin17) unstable; urgency=medium
+
+  * fix: sw64 getpriority wrong 
+
+ -- hudeng <hudeng@deepin.org>  Tue, 19 Aug 2025 18:03:01 +0800
+
 glibc (2.38-6deepin16) unstable; urgency=medium
 
   * debian/patches/git-updates.diff: update from upstream stable branch.

--- a/debian/patches/sw64/0001-feat-merge-sunway-patch-manually.patch
+++ b/debian/patches/sw64/0001-feat-merge-sunway-patch-manually.patch
@@ -43947,7 +43947,7 @@ index 00000000..cbfd1258
 +
 +sigstack	-	sigstack	2	sigstack
 +
-+getpriority	-	getpriority	i:ii	__getpriority	getpriority
++# getpriority	-	getpriority	i:ii	__getpriority	getpriority
 +
 +# proper socket implementations:
 +bind		-	bind		i:ipi	__bind		bind


### PR DESCRIPTION
直接调用sw64内核的getpriority接口返回值是非标准unix的glibc getpriority接口返回值，需要开启glibc getpriority返回值转化