### PR TITLE
perf: Backport "math: Remove ldbl-96 fma implementation"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+glibc (2.38-6deepin18) unstable; urgency=medium
+
+  * perf: Backport "math: Remove ldbl-96 fma implementation"
+
+ -- WangYuli <wangyl5933@chinaunicom.cn>  Mon, 24 Nov 2025 10:09:10 +0800
+
 glibc (2.38-6deepin17) unstable; urgency=medium
 
   * fix: sw64 getpriority wrong 

--- a/debian/patches/all/math-Remove-ldbl-96-fma-implementation.patch
+++ b/debian/patches/all/math-Remove-ldbl-96-fma-implementation.patch
@@ -1,0 +1,41 @@
+From 2f82c397b06868c9e9405e5a955a05cc1ae36225 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Thu, 13 Nov 2025 09:58:19 -0300
+Subject: [PATCH] math: Remove ldbl-96 fma implementation
+
+commit 42f07a44ef88e0c9ff1bd5343786013272467414 upstream.
+
+It is worse than the ldbl-64 version on recent x86 hardware.  With
+Zen3 and gcc-15:
+
+ldbl-96 removal
+reciprocal-throughput        master        patched   improvement
+x86_64                    1176.2200       289.4640         4.06x
+i686                      1476.0600       636.8660         2.32x
+
+latency                      master        patched   improvement
+x86_64                    1176.2200        293.7360        4.00x
+i686                      1480.0700        658.4160        2.25x
+
+Checked on x86_64-linux-gnu and i686-linux-gnu.
+
+Reviewed-by: Wilco Dijkstra  <Wilco.Dijkstra@arm.com>
+[ WangYuli: Resolved conflicts. ]
+Signed-off-by: WangYuli <wangyl5933@chinaunicom.cn>
+---
+ sysdeps/i386/i686/multiarch/s_fma.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sysdeps/i386/i686/multiarch/s_fma.c b/sysdeps/i386/i686/multiarch/s_fma.c
+index 1b9ecb46..934a59e2 100644
+--- a/sysdeps/i386/i686/multiarch/s_fma.c
++++ b/sysdeps/i386/i686/multiarch/s_fma.c
+@@ -38,4 +38,4 @@ libm_alias_double_narrow (__fma, fma)
+ 
+ #define __fma __fma_ia32
+ 
+-#include <sysdeps/ieee754/ldbl-96/s_fma.c>
++#include <sysdeps/ieee754/dbl-64/s_fma.c>
+-- 
+2.51.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -166,3 +166,5 @@ zhaoxin/0002-x86_64-Optimize-large-size-copy-in-memmove-ssse3.patch
 zhaoxin/0003-x86-Set-default-non_temporal_threshold-for-Zhaoxin-p.patch
 
 localedata/Unicode_15_1_0_support.patch
+
+all/math-Remove-ldbl-96-fma-implementation.patch


### PR DESCRIPTION
[ Origin message: ]

  It is worse than the ldbl-64 version on recent x86 hardware.  With
  Zen3 and gcc-15:

  ldbl-96 removal
  reciprocal-throughput        master        patched   improvement
  x86_64                    1176.2200       289.4640         4.06x
  i686                      1476.0600       636.8660         2.32x

  latency                      master        patched   improvement
  x86_64                    1176.2200        293.7360        4.00x
  i686                      1480.0700        658.4160        2.25x

  Checked on x86_64-linux-gnu and i686-linux-gnu.