### PR TITLE
fix: exclude tst-malloc-too-large from hugetlb2 tests to prevent CI t…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+glibc (2.38-6deepin23) unstable; urgency=medium
+
+  * Exclude tst-malloc-too-large from hugetlb2 tests to fix timeout on CI
+    - When GLIBC_TUNABLES=glibc.malloc.hugetlb=2 is set, the test triggers
+      MAP_HUGETLB mmap calls for impossibly large sizes (near SIZE_MAX),
+      which hit the kernel slow path and time out (default 20s * factor)
+      on the shuttle CI builder environment
+    - The test purpose is to verify ENOMEM on too-large allocations, which
+      is unrelated to huge page functionality; excluding it matches the
+      existing exclusion of tst-free-errno for the same reason
+
+ -- lichenggang <lichenggang@uniontech.com>  Sat, 18 Apr 2026 09:55:52 +0800
+
 glibc (2.38-6deepin22) unstable; urgency=medium
 
   * Fix git-updates.diff tab indentation in check-dt-x86-64-plt recipe

--- a/debian/patches/loong64/0058-malloc-Exclude-tst-malloc-too-large-from-hugetlb2.patch
+++ b/debian/patches/loong64/0058-malloc-Exclude-tst-malloc-too-large-from-hugetlb2.patch
@@ -1,0 +1,14 @@
+diff --git a/malloc/Makefile b/malloc/Makefile
+index c1db3347..3a4d03a7 100644
+--- a/malloc/Makefile
++++ b/malloc/Makefile
+@@ -103,7 +103,8 @@ tests-exclude-hugetlb1 = \
+ # overlapping region.
+ tests-exclude-hugetlb2 = \
+ 	$(tests-exclude-hugetlb1) \
+-	tst-free-errno
++	tst-free-errno \
++	tst-malloc-too-large
+ tests-malloc-hugetlb1 = \
+ 	$(filter-out $(tests-exclude-hugetlb1), $(tests))
+ tests-malloc-hugetlb2 = \

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -166,6 +166,7 @@ loong64/0054-LoongArch-Fix-build-failure-for-loongarch64-linux-gn.patch
 loong64/0055-malloc-Fix-tst-bug-in-malloc-tst-free-errno-malloc-h.patch
 loong64/0056-LoongArch-Call-elf_ifunc_invoke-for-R_LARCH_IRELATIV.patch
 loong64/0057-LoongArch-Use-generic-__builtin_trap-in-abort.patch
+loong64/0058-malloc-Exclude-tst-malloc-too-large-from-hugetlb2.patch
 
 iconvdata/add_GB18030-2022_charmap_and_test_the_entire_GB18030_charmap.patch
 


### PR DESCRIPTION
…imeout

The tst-malloc-too-large test repeatedly allocates and frees small blocks then tries to allocate impossibly large sizes near SIZE_MAX and PTRDIFF_MAX on 64-bit targets. When run with GLIBC_TUNABLES=glibc.malloc.hugetlb=2, each large allocation triggers mmap(..., MAP_HUGETLB) which hits the kernel slow path for huge page allocation failure. On the shuttle CI builder environment this causes the test to exceed its timeout (20s * TIMEOUTFACTOR) and get killed, failing the entire glibc build.

This exclusion follows the same pattern as tst-free-errno which is already excluded from hugetlb2 for a similar reason (it relies on specific malloc page size behavior). The test's purpose (verifying ENOMEM on too-large allocations) is unrelated to huge page functionality.

Log: Exclude tst-malloc-too-large from hugetlb2 tests to fix CI timeout

Influence:
1. Verify glibc builds successfully on loong64 in shuttle CI
2. Ensure tst-malloc-too-large still passes in standard and hugetlb1 modes
3. Confirm no regression in other malloc hugetlb2 tests
4. Check that the patch applies cleanly during package build

fix: 将 tst-malloc-too-large 从 hugetlb2 测试中排除以修复 CI 超时

tst-malloc-too-large 测试在 64 位目标上反复分配和释放小块内存，然后尝
试分配接近 SIZE_MAX 和 PTRDIFF_MAX 的极大尺寸。当使用
GLIBC_TUNABLES=glibc.malloc.hugetlb=2 运行时，每次大分配都会触发 mmap(..., MAP_HUGETLB)，在内核 huge page 分配失败路径上耗时极长。在 shuttle CI 构建环境中，这导致测试超过超时限制（20s * TIMEOUTFACTOR）
并被杀死，导致整个 glibc 构建失败。

此排除遵循与 tst-free-errno 相同的模式（后者已因类似原因被排除在
hugetlb2 之外）。该测试的目的（验证过大分配返回 ENOMEM）与 huge page
功能无关。

Log: 将 tst-malloc-too-large 从 hugetlb2 测试中排除以修复 CI 超时

Influence:
1. 验证 glibc 在 loong64 shuttle CI 上可以成功构建
2. 确保 tst-malloc-too-large 在标准模式和 hugetlb1 模式下仍能通过
3. 确认其他 malloc hugetlb2 测试没有回归
4. 检查 patch 在包构建过程中能干净地应用

repo: glibc #fix/glibc-lcall-tab-indent