### PR TITLE
fix(locales): handle leading spaces in /etc/locale.gen parsing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+glibc (2.38-6deepin23) unstable; urgency=medium
+
+  * Fix: handle leading spaces in /etc/locale.gen configuration.
+
+ -- liujianqiang <liujianqiang@uniontech.com>  Thu, 07 May 2026 15:05:29 +0800
+
 glibc (2.38-6deepin22) unstable; urgency=medium
 
   * Fix git-updates.diff tab indentation in check-dt-x86-64-plt recipe

--- a/debian/debhelper.in/locales.config
+++ b/debian/debhelper.in/locales.config
@@ -30,7 +30,7 @@ fi
 
 # List of locales in /etc/locale.gen
 if [ -e $LG ]; then
-  GEN_LOCALES="$(sed -e '/^[a-zA-Z]/!d' -e 's/ *$//g' $LG)"
+  GEN_LOCALES="$(sed -e '/^\s*[a-zA-Z]/!d' -e 's/^\s*//g' -e 's/\s*$//g' $LG)"
   GEN_LOCALES="$(convert_locale "$GEN_LOCALES")"
 fi
 


### PR DESCRIPTION
Fix sed pattern in locales.config to correctly parse locale entries that have leading whitespace characters in /etc/locale.gen. Previously, lines starting with spaces were silently skipped because the regex only matched lines beginning with [a-zA-Z]. Updated the sed expression to allow optional leading whitespace and strip both leading and trailing spaces from matched lines.

Log: Fix locale.gen parsing to handle leading whitespace in entries

Influence:
1. Verify locales with leading spaces in /etc/locale.gen are correctly listed in dpkg-reconfigure locales
2. Verify locales without leading spaces still work as before (regression)
3. Verify trailing whitespace is properly stripped from locale entries
4. Test debconf locale selection includes all valid locales from locale.gen

fix(locales): 修复 /etc/locale.gen 行首空格导致 locale 解析失败

修复 locales.config 中 sed 模式无法正确解析 /etc/locale.gen 中 行首带有空白字符的 locale 条目的问题。此前，行首有空格的条目
会被静默跳过，因为正则只匹配以 [a-zA-Z] 开头的行。
更新 sed 表达式，允许行首可选空白字符，并去除行首和行尾空格。

Log: 修复 locale.gen 解析，支持条目行首空白字符

Influence:
1. 验证 /etc/locale.gen 中行首有空格的 locale 能在 dpkg-reconfigure locales 中正确列出
2. 验证行首无空格的 locale 仍正常工作（回归）
3. 验证 locale 条目行尾空白字符被正确去除
4. 测试 debconf locale 选择界面包含 locale.gen 中所有有效条目

PMS: BUG-358875