### PR TITLE
fix(debian): mark cpuinfo feature tests xfail in pbuilder

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+glibc (2.38-6deepin25) unstable; urgency=medium
+
+  * Fix mark cpuinfo feature tests xfail in pbuilder.
+
+ -- liujianqiang <liujianqiang@uniontech.com>  Mon, 25 May 2026 13:17:41 +0800
+
 glibc (2.38-6deepin24) unstable; urgency=medium
 
   * Fix CVE-2026-4046: Use pending character state in IBM1390, IBM1399

--- a/debian/testsuite-xfail-debian.mk
+++ b/debian/testsuite-xfail-debian.mk
@@ -15,6 +15,12 @@ test-xfail-tst-create-detached = yes
 # difference between /build/... and /var/cache/pbuilder/build/.../build/...
 test-xfail-tst-lchmod = yes
 
+# x86 cpu feature tests read /proc/cpuinfo directly. In pbuilder this is not
+# consistently available for all multilib passes, which makes the tests fail
+# in clean chroot builds.
+test-xfail-tst-cpu-features-cpuinfo = yes
+test-xfail-tst-cpu-features-cpuinfo-static = yes
+
 ######################################################################
 # alpha
 ######################################################################
@@ -231,8 +237,6 @@ test-xfail-tst-null-argv = yes
 
 # We don't provide /proc/cpuinfo yet
 test-xfail-test-multiarch = yes
-test-xfail-tst-cpu-features-cpuinfo = yes
-test-xfail-tst-cpu-features-cpuinfo-static = yes
 
 # Need actual porting
 test-xfail-exe = yes


### PR DESCRIPTION
Move the x86 cpu feature tests that read /proc/cpuinfo to the global Debian xfail list so they are consistently expected to fail in pbuilder multilib passes.
Remove the same entries from the Hurd-specific section because the issue is tied to clean chroot build environments rather than Hurd itself.

Log: Reclassify cpuinfo feature test xfails for pbuilder multilib builds

Influence:
1. Verify Debian test expectations for tst-cpu-features-cpuinfo in pbuilder-based multilib builds.
2. Confirm tst-cpu-features-cpuinfo-static is treated as xfail across the affected clean chroot passes.
3. Check that the Hurd-specific xfail list no longer carries these entries and keeps architecture-specific expectations intact.